### PR TITLE
Homework 4

### DIFF
--- a/kubernetes_manifests/app.py
+++ b/kubernetes_manifests/app.py
@@ -1,0 +1,83 @@
+import logging
+import os
+import pickle
+import time
+from typing import List, Optional, Union
+
+import pandas as pd
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sklearn.pipeline import Pipeline
+
+DEFAULT_PATH_TO_MODEL = "models/model.pkl"
+
+logger = logging.getLogger(__name__)
+
+
+def load_object(path: str) -> Pipeline:
+    with open(path, "rb") as f:
+        return pickle.load(f)
+
+
+class HeartDiseaseModel(BaseModel):
+    data: List[Union[float, str, None]]
+    features: List[str]
+
+
+class HeartDiseaseResponse(BaseModel):
+    id: str
+    condition: float
+
+
+model: Optional[Pipeline] = None
+
+
+def make_predict(
+    data: List, features: List[str], model: Pipeline
+) -> List[HeartDiseaseResponse]:
+    data = pd.DataFrame([data], columns=features)
+    preds = model.predict(data)
+
+    return [
+        HeartDiseaseResponse(id=id_, condition=pred) for id_, pred in enumerate(preds)
+    ]
+
+
+app = FastAPI()
+
+
+@app.get("/")
+def main():
+    return "it is entry point of our predictor"
+
+
+@app.on_event("startup")
+def load_model():
+    global model
+    model_path = os.getenv("PATH_TO_MODEL", DEFAULT_PATH_TO_MODEL)
+    if model_path is None:
+        err = f"PATH_TO_MODEL {model_path} is None"
+        logger.error(err)
+        raise RuntimeError(err)
+
+    model = load_object(model_path)
+
+
+@app.get("/health")
+def health() -> bool:
+    start_time = time.time()
+    time.sleep(30)
+    if time.time() - start_time > 20:
+        raise RuntimeError("Not responding")
+
+    return model is not None
+
+
+@app.get("/predict/", response_model=List[HeartDiseaseResponse])
+def predict(request: HeartDiseaseModel):
+    return make_predict(request.data, request.features, model)
+
+
+if __name__ == "__main__":
+    uvicorn.run("app:app", host="0.0.0.0", port=os.getenv("PORT", 8000))

--- a/kubernetes_manifests/online-inference-deployment-blue-green.yaml
+++ b/kubernetes_manifests/online-inference-deployment-blue-green.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: online-inference-deployment-blue-green
+  labels:
+    app: online-inference
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference-deployment-blue-green
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: ivanovnikolayyy/made_ml_in_prod:latest
+          name: online-inference-deployment-blue-green
+          ports:
+            - containerPort: 80

--- a/kubernetes_manifests/online-inference-deployment-rolling-update.yaml
+++ b/kubernetes_manifests/online-inference-deployment-rolling-update.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: online-inference-deployment-rolling-update
+  labels:
+    app: online-inference
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference-deployment-rolling-update
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: ivanovnikolayyy/made_ml_in_prod:latest
+          name: online-inference-deployment-rolling-update
+          ports:
+            - containerPort: 80

--- a/kubernetes_manifests/online-inference-pod-probes.yaml
+++ b/kubernetes_manifests/online-inference-pod-probes.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference-probes
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - name: online-inference-probes
+      image: ivanovnikolayyy/made_ml_in_prod:v2
+      ports:
+        - containerPort: 8000
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        initialDelaySeconds: 20
+        periodSeconds: 5
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        initialDelaySeconds: 20
+        periodSeconds: 5

--- a/kubernetes_manifests/online-inference-pod-resources.yaml
+++ b/kubernetes_manifests/online-inference-pod-resources.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference-requests-limits
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - image: ivanovnikolayyy/made_ml_in_prod:latest
+      name: online-inference-requests-limits
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "1"
+        limits:
+          memory: "128Mi"
+          cpu: "2"
+      ports:
+        - containerPort: 80

--- a/kubernetes_manifests/online-inference-pod.yaml
+++ b/kubernetes_manifests/online-inference-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - name: online-inference
+      image: ivanovnikolayyy/made_ml_in_prod:latest
+      ports:
+        - containerPort: 80

--- a/kubernetes_manifests/online-inference-pod.yaml
+++ b/kubernetes_manifests/online-inference-pod.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: online-inference
+  name: online-inference-simple
   labels:
     app: online-inference
 spec:
   containers:
-    - name: online-inference
+    - name: online-inference-simple
       image: ivanovnikolayyy/made_ml_in_prod:latest
       ports:
         - containerPort: 80

--- a/kubernetes_manifests/online-inference-replicaset.yaml
+++ b/kubernetes_manifests/online-inference-replicaset.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: online-inference-replicaset
+  labels:
+    app: online-inference-replicaset
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: online-inference-replicaset
+  template:
+    metadata:
+      name: online-inference-replicaset
+      labels:
+        app: online-inference-replicaset
+    spec:
+      containers:
+        - image: ivanovnikolayyy/made_ml_in_prod:latest
+          name: online-inference-replicaset
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
1. Kubernetes развернут локально (5 баллов)
<img width="928" alt="image" src="https://user-images.githubusercontent.com/43745219/175831844-f17cd55f-e650-4c35-a335-063a7db40ffb.png">

2. Напишите простой Pod manifest для вашего приложения, назовите его online-inference-pod.yaml (4 балла)
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/43745219/175831420-173090a8-c5b3-4a45-913b-8163d7e2dfd0.png">

3. Пропишите Requests / Limits и напишите, зачем это нужно в описании PR. Закоммитьте файл online-inference-pod-resources.yaml (2 балла)

4. Модифицируйте свое приложение так, чтобы оно стартовало не сразу (с задержкой 20-30 секунд) и падало спустя минуты работы. 
Модифицированное приложение положил в папку kubernetes_manifests. Под стартует и с задержкой 20 секунд вызывается readiness проба, в результате чего приложение падает с RuntimeError. В свою очередь liveness проба пытается переподнять под, но падает по аналогичной причине

5. Создайте ReplicaSet, сделайте 3 реплики вашего приложения. Закоммитьте online-inference-replicaset.yaml (3 балла)
Если сменить docker образ в манифесте и одновременно с этим:
а) уменьшить число реплик, то останется это количество реплик со старой версией приложения
б) увеличить число реплик, то новые реплики поднимутся с новой версией приложения, а старые останутся без изменений

6. Опишите Deployment для вашего приложения (3 балла) Играя с параметрами деплоя (maxSurge, maxUnavaliable), добейтесь ситуации, когда при деплое новой версии:
a) online-inference-deployment-blue-green.yaml - есть момент времени, когда на кластере существуют как все старые поды, так и все новые. Это поведение достигается за счет того, что параметр maxSurge равен количеству реплик replicas
б) online-inference-deployment-rolling-update.yaml - одновременно с поднятием новых версий, гасятся старые. Это поведение достигается за счет того, что параметр maxSurge и maxUnavaliable оба равны единице

Итого согласно самооценке: 20 баллов